### PR TITLE
Feature/hq 400 show invite code on home page and support sharing to s…

### DIFF
--- a/components/v2/Home/InviteCodeCard/index.tsx
+++ b/components/v2/Home/InviteCodeCard/index.tsx
@@ -45,7 +45,10 @@ const InviteCodeCard: FC<InviteCodeCardProps> = (props) => {
   }, [userInfo]);
 
   const { run: completeProgress, loading } = useRequest(
-    webApi.missionCenterApi.missionClaim,
+    async (missionIds: string[]) => {
+      const res = await webApi.missionCenterApi.missionClaim(missionIds);
+      return res;
+    },
     {
       onSuccess(res) {
         message.success('success!');
@@ -179,12 +182,15 @@ const InviteCodeCard: FC<InviteCodeCardProps> = (props) => {
             </div>
             <Button
               type="primary"
+              loading={loading}
               onClick={() => {
                 if (!inviteProgress.claimed && inviteProgress.completed) {
                   completeProgress([inviteProgress.id || '']);
                 }
               }}
-              disabled={inviteProgress.claimed || !inviteProgress.completed}
+              disabled={
+                inviteProgress.claimed || !inviteProgress.completed || loading
+              }
               className={cn(
                 `px-5 py-2 font-next-book text-[14px] text-[0B0B0B] leading-[125%] tracking-[0.28px]`,
                 inviteProgress.claimed || !inviteProgress.completed


### PR DESCRIPTION
…ocial media apps (#452)

* feat: add invitation code card is displayed in the home

* feat: add invite code card api data

* feat: adding a shared template extension

* feat: add button loading props

* feat: add loading effect to the button

* feat: update button loading style

* feat: update treasures modal structure

* feat: update treasure modal open interface

* feat: update treasure modal open interface

* feat: add treasure modal dig callback

* feat: dig treasure

* feat: digging the treasure chest can also be triggered when clicking next

* feat: update share pop box

* feat: fixed mission claim error